### PR TITLE
불필요한 기호 제거

### DIFF
--- a/textrank/summarizer.py
+++ b/textrank/summarizer.py
@@ -179,10 +179,10 @@ class KeysentenceSummarizer:
 
         Usage
         -----
-            >>> from textrank import KeysentenceSummarizer
+            from textrank import KeysentenceSummarizer
 
-            >>> summarizer = KeysentenceSummarizer(tokenize = tokenizer, min_sim = 0.5)
-            >>> keysents = summarizer.summarize(texts, topk=30)
+            summarizer = KeysentenceSummarizer(tokenize = tokenizer, min_sim = 0.5)
+            keysents = summarizer.summarize(texts, topk=30)
         """
         n_sents = len(sents)
         if isinstance(bias, np.ndarray):


### PR DESCRIPTION
해당 기호가 주석에 포함되어있으면 문법 오류를 일으킵니다.
좋은 자료 감사합니다.