### PR TITLE
윈도우 cp949 환경에서의 설치를 위해 encoding="utf-8" 옵션 추가

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='soy.lovit@gmail.com',
     description='TextRank based Summarizer (Keyword and key-sentence extractor)',
     packages=find_packages(),
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding="utf-8").read(),
     zip_safe=False,
     setup_requires=[]
 )


### PR DESCRIPTION
윈도우 cp949 환경에서는 `open` 함수에 대한 디폴트 인코딩을 cp949로 처리하므로 설치 시에 유니코드 오류가 발생합니다.

그래서 `open` 함수에 명시적으로 `encoding="utf-8"` 옵션을 넣도록 개선해봤습니다.